### PR TITLE
fix: set output to os.Stdout and os.Stderr

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -1,27 +1,17 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
+	"os"
 	"os/exec"
 )
 
 // Execute is used to run a command and print
 // the value in stdout and stderr
 func Execute(command []string) {
-	var out, stderr bytes.Buffer
-
 	cmd := exec.Command(command[0], command[1:]...)
 
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
-	if err != nil {
-		fmt.Println(err.Error())
-		fmt.Print(stderr.String())
-		return
-	}
-
-	fmt.Print(out.String())
+	cmd.Run()
 }


### PR DESCRIPTION
Previously, the Execute function would output the initial stderr
or stdout value when executing the command. However, further output
generated by the command (such as program logs) is no longer
available after wait-for-it exits. This update replaces the locally
defined buffers with os.Stdout and os.Stderr so that output
continues to be captured.