### PR TITLE
feat: add graceful shutdown support (sigterm)

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 )
 
 // Execute is used to run a command and print the value in stdout and stderr.
@@ -10,17 +13,30 @@ import (
 // The return value contains the command's exit code.
 func Execute(command []string) int {
 	cmd := exec.Command(command[0], command[1:]...)
-
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return exitError.ExitCode()
-		}
-
+	err := cmd.Start()
+	if err != nil {
+		Log("unable to start " + err.Error())
 		return -1
 	}
 
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
+	<-sigint
+
+	err = cmd.Process.Signal(os.Interrupt)
+	if err != nil {
+		Log("unable send interrupt " + err.Error())
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		return -1
+	}
 	return 0
 }


### PR DESCRIPTION
`wait-for-it` is currently missing support for gracefully shutting down a process that it starts. This adds support for that.